### PR TITLE
Fixed 'authentication' typo

### DIFF
--- a/addons/graphql.md
+++ b/addons/graphql.md
@@ -236,7 +236,7 @@ export const addPost = async ({ state, effects }, title) => {
 
 There are two points of options in the Graphql factory. The **headers** and the **options**.
 
-The headers option is a function which receives the state of the application. That means you can produce request headers dynamically. This can be useful related to authentciation.
+The headers option is a function which receives the state of the application. That means you can produce request headers dynamically. This can be useful related to authentication.
 
 {% tabs %}
 {% tab title="overmind/onInitialize.js" %}


### PR DESCRIPTION
Just caught this while digging through docs. 💪 