### PR TITLE
Use 'derived' for derived lists.

### DIFF
--- a/guides-1/managing-lists.md
+++ b/guides-1/managing-lists.md
@@ -31,9 +31,11 @@ In Overmind it is encouraged that you derive these dictionaries of entities to a
 {% tabs %}
 {% tab title="overmind/state.js" %}
 ```typescript
+import { derived } from 'overmind';
+
 export const state = {
   posts: {}
-  postsList: state => Object.values(state.posts)
+  postsList: derived(state => Object.values(state.posts))
 }
 ```
 {% endtab %}


### PR DESCRIPTION
If you leave out the derived function you'll simply get a function instead of an array. Took me hours to find that out. I guess the documentation here is out of date?