### PR TITLE
Typo fixes for gql options documentation

### DIFF
--- a/addons/graphql.md
+++ b/addons/graphql.md
@@ -236,7 +236,7 @@ export const addPost = async ({ state, effects }, title) => {
 
 There are two points of options in the Graphql factory. The **headers** and the **options**.
 
-The headers option is a function which receives the state of the application. That means you can produce request headers dynamically. This can be useful related to authentciation.
+The headers option is a function which receives the state of the application. That means you can produce request headers dynamically. This can be useful related to authentication.
 
 {% tabs %}
 {% tab title="overmind/onInitialize.js" %}


### PR DESCRIPTION
`authentciation` -> `authentication`

@christianalfoni there's a line about the headers option being a function that receives state that is a little unclear. The example from the docs shows state coming from the instance, rather than the function being used for `headers`—based on the text, my first thought was that `headers` ends up looking like this:

```ts
{
  // ...,
  headers: (state) => ({
    Authorization: `Bearer ${state.auth.token}`
  })
}
```