### PR TITLE
Remove tabs for quickstart setup code

### DIFF
--- a/quickstart.md
+++ b/quickstart.md
@@ -4,21 +4,27 @@ From the command line install the Overmind package:
 
 {% tabs %}
 {% tab title="React" %}
+
 ```
 npm install overmind overmind-react
 ```
+
 {% endtab %}
 
 {% tab title="Vue" %}
+
 ```
 npm install overmind overmind-vue
 ```
+
 {% endtab %}
 
 {% tab title="Angular" %}
+
 ```text
 npm install overmind overmind-angular
 ```
+
 {% endtab %}
 {% endtabs %}
 
@@ -26,38 +32,47 @@ npm install overmind overmind-angular
 
 Now set up a simple application like this:
 
-{% tabs %}
-{% tab title="overmind/state.js" %}
-```javascript
-export const state = {
-  title: 'My App'
-}
-```
-{% endtab %}
+**Application state**
 
-{% tab title="overmind/index.js" %}
-```typescript
-import { state } from './state'
+This contains the initial state of the application.
+
+```javascript
+// overmind/state.js
+export const state = {
+  title: "My App",
+};
+```
+
+**Application config**
+
+This contains the sate, effects and actions. For now, we just
+set the state.
+
+```javascript
+// overmind/index.js
+import { state } from "./state";
 
 export const config = {
-  state
-}
+  state,
+};
 ```
-{% endtab %}
 
-{% tab title="index.js" %}
-```typescript
-import { createOvermind } from 'overmind'
-import { config } from './overmind'
+**Create application**
 
-const overmind = createOvermind(config)
+This is where you boot your application by linking all the pieces together.
+
+```javascript
+// index.js
+import { createOvermind } from "overmind";
+import { config } from "./overmind";
+
+const overmind = createOvermind(config);
+// ... see below on how to link the overmind instance to specific view layers.
 ```
-{% endtab %}
-{% endtabs %}
 
-And fire up your application in the browser or whatever environment your user interface is to be consumed in by the users.
+And fire up your application in the browser or whatever environment your user
+interface is to be consumed in by the users.
 
 Move on with the specific view layer of choice to connect your app:
 
 \*\*\*\*[**REACT** ](views/react.md)**-** [**ANGULAR**](views/angular.md) **-** [**VUE**](views/vue.md)\*\*\*\*
-


### PR DESCRIPTION
The tabs are confusing and people will miss very important steps because in the rest of the docs, the tabs mostly mean **OR** (react OR vue, typescript OR javascript). But here they are used as an **AND** (do this AND that AND that)...

![image](https://user-images.githubusercontent.com/79422935/111905540-7b8e4100-8a4c-11eb-8af4-3bc98d58df4f.png)
