### PR TITLE
fix(update-reactions-doc): use "useReaction" hook

### DIFF
--- a/api-1/reaction.md
+++ b/api-1/reaction.md
@@ -51,10 +51,10 @@ With components you typically use reactions to manipulate DOM elements or other 
 {% tab title="React" %}
 ```typescript
 import * as React from 'react'
-import { useOvermind } from '../overmind'
+import { useReaction } from '../overmind'
 
 const App = () => {
-  const { reaction } = useOvermind()
+  const reaction = useReaction()
 
   React.useEffect(() => reaction(
     ({ currentPage }) => currentPage,


### PR DESCRIPTION
Hello @christianalfoni !

Docs about reaction still shows `useOvermind`.
It was removed in version 28: https://gist.github.com/christianalfoni/842df6eb5a7d115b52e9462849d5ed85#react

`useReaction` is used instead.