### PR TITLE
Add missing angular install

### DIFF
--- a/quickstart.md
+++ b/quickstart.md
@@ -17,7 +17,7 @@ npm install overmind overmind-vue
 
 {% tab title="Angular" %}
 ```text
-
+npm install overmind overmind-angular
 ```
 {% endtab %}
 


### PR DESCRIPTION
On the getting started page `npm install overmind overmind-angular` was missing.