### PR TITLE
use forkUserType in action

### DIFF
--- a/api-1/operators.md
+++ b/api-1/operators.md
@@ -125,7 +125,7 @@ import { pipe, fork } from 'overmind'
 
 export const getUser = pipe(
   ({ effects }) => effects.api.getUser(),
-  fork((_, user) => user.type, {
+  forkUserType({
     'admin': o.doThis,
     'superuser': o.doThat
   })


### PR DESCRIPTION
Fix documentation for operator `fork`, so that the action uses the user-defined operator `forkUserType`.